### PR TITLE
Fix webagent android build artifact action deprecation

### DIFF
--- a/webagent/.github/workflows/build-apk.yml
+++ b/webagent/.github/workflows/build-apk.yml
@@ -35,14 +35,14 @@ jobs:
       continue-on-error: true
       
     - name: Upload debug APK
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: app-debug-apk
         path: app/build/outputs/apk/debug/app-debug.apk
         retention-days: 30
         
     - name: Upload release APK
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: app-release-apk
         path: app/build/outputs/apk/release/app-release.apk


### PR DESCRIPTION
Update `actions/upload-artifact` to v4 to resolve deprecation warnings.

GitHub's `actions/upload-artifact@v3` is being deprecated, causing warnings in the Android build workflow. This PR updates the action to v4 to ensure continued compatibility and remove these warnings.

---
<a href="https://cursor.com/background-agent?bcId=bc-ec4e7e26-f0d7-43d4-a52e-992a9821795e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ec4e7e26-f0d7-43d4-a52e-992a9821795e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

