### PR TITLE
Enable on-demand apk build action

### DIFF
--- a/webagent/.github/workflows/build-apk.yml
+++ b/webagent/.github/workflows/build-apk.yml
@@ -6,6 +6,21 @@ on:
   pull_request:
     branches: [ main ]
   workflow_dispatch:
+    inputs:
+      build_type:
+        description: '빌드 타입 선택'
+        required: true
+        default: 'both'
+        type: choice
+        options:
+          - both
+          - debug
+          - release
+      branch:
+        description: '빌드할 브랜치'
+        required: false
+        default: ''
+        type: string
 
 jobs:
   build:
@@ -13,28 +28,33 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.inputs.branch || github.ref }}
       
     - name: Set up JDK 17
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         java-version: '17'
         distribution: 'temurin'
         
     - name: Setup Android SDK
-      uses: android-actions/setup-android@v2
+      uses: android-actions/setup-android@v3
       
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
       
     - name: Build debug APK
+      if: github.event.inputs.build_type == 'both' || github.event.inputs.build_type == 'debug' || github.event_name != 'workflow_dispatch'
       run: ./gradlew assembleDebug
       
     - name: Build release APK
+      if: github.event.inputs.build_type == 'both' || github.event.inputs.build_type == 'release' || github.event_name != 'workflow_dispatch'
       run: ./gradlew assembleRelease
       continue-on-error: true
       
     - name: Upload debug APK
+      if: github.event.inputs.build_type == 'both' || github.event.inputs.build_type == 'debug' || github.event_name != 'workflow_dispatch'
       uses: actions/upload-artifact@v4
       with:
         name: app-debug-apk
@@ -42,6 +62,7 @@ jobs:
         retention-days: 30
         
     - name: Upload release APK
+      if: github.event.inputs.build_type == 'both' || github.event.inputs.build_type == 'release' || github.event_name != 'workflow_dispatch'
       uses: actions/upload-artifact@v4
       with:
         name: app-release-apk


### PR DESCRIPTION
Enhance `build-apk.yml` workflow to allow manual execution with selectable build type and branch.

---
<a href="https://cursor.com/background-agent?bcId=bc-a365e489-fc04-4537-a26f-094649f0d505"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a365e489-fc04-4537-a26f-094649f0d505"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

