### PR TITLE
Move build apk workflow to webagent

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -42,14 +42,17 @@ jobs:
       uses: android-actions/setup-android@v3
       
     - name: Grant execute permission for gradlew
+      working-directory: webagent
       run: chmod +x gradlew
       
     - name: Build debug APK
       if: github.event.inputs.build_type == 'both' || github.event.inputs.build_type == 'debug' || github.event_name != 'workflow_dispatch'
+      working-directory: webagent
       run: ./gradlew assembleDebug
       
     - name: Build release APK
       if: github.event.inputs.build_type == 'both' || github.event.inputs.build_type == 'release' || github.event_name != 'workflow_dispatch'
+      working-directory: webagent
       run: ./gradlew assembleRelease
       continue-on-error: true
       
@@ -58,7 +61,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: app-debug-apk
-        path: app/build/outputs/apk/debug/app-debug.apk
+        path: webagent/app/build/outputs/apk/debug/app-debug.apk
         retention-days: 30
         
     - name: Upload release APK
@@ -66,6 +69,6 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: app-release-apk
-        path: app/build/outputs/apk/release/app-release.apk
+        path: webagent/app/build/outputs/apk/release/app-release.apk
         retention-days: 30
         if-no-files-found: ignore


### PR DESCRIPTION
Move `build-apk.yml` workflow to the root `.github/workflows` directory and update paths to operate within `webagent`.

---
<a href="https://cursor.com/background-agent?bcId=bc-d159eea8-7fed-4a48-bb6f-c517d6f88de6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d159eea8-7fed-4a48-bb6f-c517d6f88de6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

