### PR TITLE
Fix webagent android resource linking error

### DIFF
--- a/webagent/app/src/main/AndroidManifest.xml
+++ b/webagent/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.webagent.app">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <!-- Internet permission -->
     <uses-permission android:name="android.permission.INTERNET" />

--- a/webagent/app/src/main/res/xml/preferences.xml
+++ b/webagent/app/src/main/res/xml/preferences.xml
@@ -15,16 +15,14 @@
             app:title="Gemini API Key"
             app:summary="Google Gemini API 키를 입력하세요"
             app:dialogTitle="Gemini API Key"
-            app:dialogMessage="API 키를 입력하세요"
-            app:inputType="text" />
+            app:dialogMessage="API 키를 입력하세요" />
 
         <EditTextPreference
             app:key="chatgpt_api_key"
             app:title="ChatGPT API Key"
             app:summary="OpenAI ChatGPT API 키를 입력하세요"
             app:dialogTitle="ChatGPT API Key"
-            app:dialogMessage="API 키를 입력하세요"
-            app:inputType="text" />
+            app:dialogMessage="API 키를 입력하세요" />
 
         <EditTextPreference
             app:key="chatgpt_api_url"
@@ -32,7 +30,6 @@
             app:summary="ChatGPT API 엔드포인트 URL"
             app:dialogTitle="ChatGPT API URL"
             app:dialogMessage="API URL을 입력하세요"
-            app:inputType="textUri"
             app:defaultValue="https://api.openai.com/v1/chat/completions" />
     </PreferenceCategory>
 


### PR DESCRIPTION
Remove deprecated `package` attribute from AndroidManifest.xml and unsupported `app:inputType` from preferences.xml.

The `package` attribute in `AndroidManifest.xml` is no longer supported, and `app:inputType` is not a valid attribute for `EditTextPreference`, causing Android resource linking failures.

---
<a href="https://cursor.com/background-agent?bcId=bc-c7fbaafb-9fcb-43fc-bce3-61cd20a06b25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c7fbaafb-9fcb-43fc-bce3-61cd20a06b25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

