### PR TITLE
Fix webagent build error

### DIFF
--- a/webagent/app/src/main/AndroidManifest.xml
+++ b/webagent/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.webagent.app">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <!-- Internet permission -->
     <uses-permission android:name="android.permission.INTERNET" />

--- a/webagent/app/src/main/res/xml/preferences.xml
+++ b/webagent/app/src/main/res/xml/preferences.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<PreferenceScreen xmlns:app="http://schemas.android.com/apk/res-auto">
+<PreferenceScreen xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:android="http://schemas.android.com/apk/res/android">
 
     <PreferenceCategory app:title="LLM 설정">
         <ListPreference
@@ -16,7 +17,7 @@
             app:summary="Google Gemini API 키를 입력하세요"
             app:dialogTitle="Gemini API Key"
             app:dialogMessage="API 키를 입력하세요"
-            app:inputType="text" />
+            android:inputType="text" />
 
         <EditTextPreference
             app:key="chatgpt_api_key"
@@ -24,7 +25,7 @@
             app:summary="OpenAI ChatGPT API 키를 입력하세요"
             app:dialogTitle="ChatGPT API Key"
             app:dialogMessage="API 키를 입력하세요"
-            app:inputType="text" />
+            android:inputType="text" />
 
         <EditTextPreference
             app:key="chatgpt_api_url"
@@ -32,7 +33,7 @@
             app:summary="ChatGPT API 엔드포인트 URL"
             app:dialogTitle="ChatGPT API URL"
             app:dialogMessage="API URL을 입력하세요"
-            app:inputType="textUri"
+            android:inputType="textUri"
             app:defaultValue="https://api.openai.com/v1/chat/completions" />
     </PreferenceCategory>
 


### PR DESCRIPTION
Remove deprecated `package` attribute from `AndroidManifest.xml` and correct `inputType` namespace in `preferences.xml` to fix Android resource linking errors.

The build failed because the `package` attribute in `AndroidManifest.xml` is no longer supported, and `inputType` attributes in `preferences.xml` were incorrectly using the `app` namespace instead of the standard `android` namespace, leading to resource linking failures.

---
<a href="https://cursor.com/background-agent?bcId=bc-c06333d2-9f4c-43e4-b374-3314af7a871c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c06333d2-9f4c-43e4-b374-3314af7a871c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

